### PR TITLE
wait for “PROMPT” method from gapi callback

### DIFF
--- a/app/scripts/controllers/login.js
+++ b/app/scripts/controllers/login.js
@@ -87,7 +87,7 @@ angular.module('stormpathIdpApp')
         scope: 'email',
         cookiepolicy: 'single_host_origin',
         callback: function(authResult){
-          if (!googleIsSignedIn && authResult.status.signed_in) {
+          if (!googleIsSignedIn && authResult.status.signed_in && authResult.status.method === 'PROMPT') {
             googleIsSignedIn = true;
             Stormpath.register({
               providerData: {


### PR DESCRIPTION
Waiting for “PROMPT” allows an already-authenticated user to select which google account they want to use

If we don’t wait, we respond to the first callback and end up leaving the ID site before the account can be selected