### PR TITLE
Show error message if email or password is omitted on login form

### DIFF
--- a/app/scripts/controllers/login.js
+++ b/app/scripts/controllers/login.js
@@ -101,6 +101,8 @@ angular.module('stormpathIdpApp')
           };
         }
         Stormpath.login(data,errHandler);
+      }else{
+        $scope.errors.emailPasswordRequired = true;
       }
     };
 

--- a/app/views/login.html
+++ b/app/views/login.html
@@ -18,6 +18,7 @@
         <span>?</span>
       </div>
       <div class="alert alert-danger" ng-show="errors.unknown">An unkown error has occurred</div>
+      <div class="alert alert-danger" ng-show="errors.emailPasswordRequired">Please enter your email and password.</div>
       <div class="alert alert-danger" ng-show="errors.userMessage">
         <strong>Sorry, an error occured.  Please reload the page and try again.</strong>
         <br/>


### PR DESCRIPTION
Otherwise the form won’t do anything, which is an awkward experience