### PR TITLE
Centralize the body

### DIFF
--- a/app/styles/main.less
+++ b/app/styles/main.less
@@ -41,7 +41,7 @@
 html,body
 {
   height: 100%;
-
+  margin: 0 auto;
   @media (max-width: @screen-xs-max){
     padding: 0 4px;
   }


### PR DESCRIPTION
Fix the default screen style.
This modification will center the login view container. See http://igorrcosta.pythonanywhere.com/login on any screen size for an example of the bug.