### PR TITLE
Changed facebook location from es_LA to en_US

### DIFF
--- a/app/scripts/controllers/login.js
+++ b/app/scripts/controllers/login.js
@@ -30,7 +30,7 @@ angular.module('stormpathIdpApp')
         }
         js = d.createElement(s);
         js.id = id;
-        js.src = '//connect.facebook.net/es_LA/sdk.js';
+        js.src = '//connect.facebook.net/en_US/sdk.js';
         fjs.parentNode.insertBefore(js, fjs);
       }($window.document, 'script', 'facebook-jssdk'));
     }


### PR DESCRIPTION
Right now if I use Facebook login on ID Site, the default language is Spanish because the value is es_LA. I changed it to en_US to make it english. 